### PR TITLE
silence the bell when <= 1 completion

### DIFF
--- a/live-completions.el
+++ b/live-completions.el
@@ -176,6 +176,9 @@ Meant to be added to `after-change-functions'."
               (save-excursion
                 (goto-char (point-max))
                 (let ((inhibit-message t)
+                      ;; don't ring the bell in `minibuffer-completion-help' 
+                      ;; when <= 1 completion exists.
+                      (ring-bell-function #'ignore)
                       (minibuffer-completion-table
                        (live-completions--sort-order-table)))
                   (minibuffer-completion-help)


### PR DESCRIPTION
`minibuffer-completion-help` rings the `bell` when there is one,
or no, completion.  This triggers quite frequently for me using `find-file`,
and live-completions.

Binding `bell-ring-function` to `ignore` silences these during the
live-completions update, but doesn't otherwise change behaviour.

That eliminates the spurious beeps without any other adverse effect.